### PR TITLE
Fix/player mutants

### DIFF
--- a/docs/bva/player.md
+++ b/docs/bva/player.md
@@ -133,6 +133,10 @@ For each test case, you may choose **any easy-to-read format** you like. Regardl
   - **State of the system**: property = null  
   - **Expected output**: rejected / no change  
 
+- **TC22b: Sell owned property with invalid price** ( :white_check_mark: )  
+  - **State of the system**: property in set, price = Double.MAX_VALUE  
+  - **Expected output**: rejected / no change  
+
 
 ## Method under test: `goToJail(int jailPosition)`
 

--- a/src/test/java/model/PlayerTests.java
+++ b/src/test/java/model/PlayerTests.java
@@ -303,6 +303,23 @@ public class PlayerTests {
         assertFalse(success, "Selling a null property should fail");
         assertEquals(100.0, player.getBalance(), 0.001, "Balance should remain unchanged");
     }
+
+    @Test
+    public void Test_Selling_Owned_Property_When_Receive_Fails() {
+        Player player = new Player("John", 100.0);
+        Property propertyMock = EasyMock.createMock(Property.class);
+
+        EasyMock.expect(propertyMock.getPrice()).andReturn(Double.MAX_VALUE);
+        EasyMock.replay(propertyMock);
+
+        player.addProperty(propertyMock);
+        boolean success = player.sellProperty(propertyMock);
+
+        assertFalse(success, "Selling should fail when receive rejects the price");
+        assertTrue(player.getOwnedProperties().contains(propertyMock),
+                "Property should remain owned when sale fails");
+        assertEquals(100.0, player.getBalance(), 0.001, "Balance should remain unchanged");
+    }
     // ==================================================================================================
     // Test suite for goToJail method
     // ==================================================================================================
@@ -494,4 +511,5 @@ public class PlayerTests {
         
         assertEquals(0, jailTurnCount, "jailTurnCount should be 0 after leaving jail");
     }
+
 }


### PR DESCRIPTION
This pull request adds a new test case and updates documentation to cover the scenario where a player attempts to sell an owned property at an invalid price (specifically, `Double.MAX_VALUE`). This ensures the system correctly rejects such sales and maintains proper state. The documentation for test cases is also updated to reflect this scenario.

**Test coverage improvements:**

* Added a unit test `Test_Selling_Owned_Property_When_Receive_Fails` in `PlayerTests.java` to verify that selling a property with an invalid price (e.g., `Double.MAX_VALUE`) is rejected, the property remains owned, and the player's balance is unchanged.

**Documentation updates:**

* Added a new test case description "TC22b: Sell owned property with invalid price" to `player.md`, specifying the expected behavior for this scenario.