### PR TITLE
Wip jailcontroller

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,8 +108,8 @@ tasks.jacocoTestReport {
 }
 
 pitest {
-    targetClasses = setOf("model.*") //by default "${project.group}.*"
-    targetTests = setOf("model.*")
+    targetClasses = setOf("model.*", "controller.*")
+    targetTests = setOf("model.*", "controller.*")
     junit5PluginVersion = "1.2.1"
     pitestVersion = "1.15.0" //not needed when a default PIT version should be used
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -95,19 +95,22 @@ tasks.jacocoTestReport {
     }
 }
 
-tasks.build {
-    dependsOn("pitest")
-}
-
 tasks.test {
-    finalizedBy(tasks.jacocoTestReport) // report is always generated after tests run
+    finalizedBy(tasks.jacocoTestReport)
     finalizedBy(tasks.pitest)
 }
+
 tasks.jacocoTestReport {
-    dependsOn(tasks.test) // tests are required to run before generating the report
+    dependsOn(tasks.test)
+}
+
+tasks.pitest {
+    dependsOn(tasks.test)
 }
 
 pitest {
+    // targetTests must cover every package in targetClasses, or PIT will show 0%
+    // line/mutation coverage (with 0 tests run) for those classes.
     targetClasses = setOf("model.*", "controller.*")
     targetTests = setOf("model.*", "controller.*")
     junit5PluginVersion = "1.2.1"

--- a/docs/bva/JailController.md
+++ b/docs/bva/JailController.md
@@ -1,0 +1,129 @@
+# JailController BVA Analysis
+
+## Method under test: `sendToJail(Player player)`
+
+Moves an active player to jail via `GameEngine.setPlayerPosition` and `Player.goToJail(Constants.JAIL_POSITION)`.
+
+- **TC1: Null player** ( )
+  - **State of the system**: `player = null`
+  - **Expected output**: `NullPointerException` thrown
+
+- **TC2: Inactive player** ( )
+  - **State of the system**: `player.getActive() = false`, `player.inJail() = false`
+  - **Expected output**: `false`; no change to jail status, position, or `jailTurnCount`
+
+- **TC3: Active player not in jail** ( )
+  - **State of the system**: `player.getActive() = true`, `player.inJail() = false`, `player.position ≠ JAIL_POSITION`
+  - **Expected output**: `true`; `player.inJail() = true`, `player.position = Constants.JAIL_POSITION`, `player.getJailTurnCount() = 1`; board position updated via `GameEngine`
+
+- **TC4: Active player already in jail** ( )
+  - **State of the system**: `player.getActive() = true`, `player.inJail() = true`, `player.getJailTurnCount() = 2`
+  - **Expected output**: `true`; `player.inJail()` remains `true`, `player.position = Constants.JAIL_POSITION`, `player.getJailTurnCount()` reset to `1` (per `Player.goToJail()` behavior)
+
+---
+
+## Method under test: `releaseFromJail(Player player)`
+
+Releases a jailed player by delegating to `Player.leaveJail()`.
+
+- **TC5: Null player** ( )
+  - **State of the system**: `player = null`
+  - **Expected output**: `NullPointerException` thrown
+
+- **TC6: Player is in jail** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getJailTurnCount() = 2`, `player.position = Constants.JAIL_POSITION`
+  - **Expected output**: `true`; `player.inJail() = false`, `player.getJailTurnCount() = 0`, `player.position` increases by 1 (per `Player.leaveJail()`)
+
+- **TC7: Player not in jail** ( )
+  - **State of the system**: `player.inJail() = false`
+  - **Expected output**: `false`; no change to jail status, position, or `jailTurnCount`
+
+---
+
+## Method under test: `payJailFee(Player player)`
+
+Deducts the jail fee and releases the player. Corresponds to game-rules Use Case 2 alternate flow step 1b.
+
+- **TC8: Null player** ( )
+  - **State of the system**: `player = null`
+  - **Expected output**: `NullPointerException` thrown
+
+- **TC9: Player not in jail** ( )
+  - **State of the system**: `player.inJail() = false`
+  - **Expected output**: `false`; balance unchanged
+
+- **TC10: Player in jail, cannot afford fee** ( )
+  - **State of the system**: `player.inJail() = true`, `player.canAfford(Constants.JAIL_FEE) = false`
+  - **Expected output**: `false`; `player.inJail()` remains `true`, balance unchanged
+
+- **TC11: Player in jail, balance exactly equals fee** ( )
+  - **State of the system**: `player.inJail() = true`, `player.balance = Constants.JAIL_FEE`
+  - **Expected output**: `true`; balance becomes `0`, player released (`inJail = false`, `jailTurnCount = 0`)
+
+- **TC12: Player in jail, balance greater than fee** ( )
+  - **State of the system**: `player.inJail() = true`, `player.balance > Constants.JAIL_FEE`
+  - **Expected output**: `true`; balance reduced by `Constants.JAIL_FEE`, player released
+
+- **TC13: Inactive player in jail** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getActive() = false`
+  - **Expected output**: `false`; no balance change, player remains in jail
+
+---
+
+## Method under test: `attemptRollDoubles(Player player)`
+
+Rolls dice for a jailed player. Corresponds to game-rules Use Case 2 alternate flow steps 1c / 1d. Uses injected `Dice`.
+
+- **TC14: Null player** ( )
+  - **State of the system**: `player = null`
+  - **Expected output**: `NullPointerException` thrown
+
+- **TC15: Player not in jail** ( )
+  - **State of the system**: `player.inJail() = false`
+  - **Expected output**: `false`; dice not rolled (or roll ignored), no jail state change
+
+- **TC16: Player in jail, dice roll is doubles** ( )
+  - **State of the system**: `player.inJail() = true`; after `dice.roll()`, `dice.isDoubles() = true`
+  - **Expected output**: `true`; player released via `releaseFromJail` (`inJail = false`, `jailTurnCount = 0`)
+
+- **TC17: Player in jail, dice roll is not doubles, turn count below max** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getJailTurnCount() = 1`; after `dice.roll()`, `dice.isDoubles() = false`
+  - **Expected output**: `false`; player remains in jail; `jailTurnCount` incremented to `2`
+
+- **TC18: Player in jail, dice roll is not doubles, turn count at max** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getJailTurnCount() = Constants.MAX_JAIL_TURNS`; after `dice.roll()`, `dice.isDoubles() = false`
+  - **Expected output**: `false`; player remains in jail; turn ends (player must pay fee on a future turn per game rules)
+
+- **TC19: Inactive player in jail** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getActive() = false`
+  - **Expected output**: `false`; no dice roll, no state change
+
+---
+
+## Method under test: `handleJailTurn(Player player)`
+
+Called when a jailed player's turn ends without release (failed doubles and fee not paid). Records the elapsed jail turn so the 3-turn boundary can be enforced. Corresponds to game-rules Use Case 2 alternate flow step 1d.
+
+- **TC20: Null player** ( )
+  - **State of the system**: `player = null`
+  - **Expected output**: `NullPointerException` thrown
+
+- **TC21: Player not in jail** ( )
+  - **State of the system**: `player.inJail() = false`
+  - **Expected output**: `false`; no state change
+
+- **TC22: Player in jail, first turn in jail (`jailTurnCount = 1`)** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getJailTurnCount() = 1`, player did not pay or roll doubles this turn
+  - **Expected output**: completes without exception; `jailTurnCount` incremented to `2`; player remains in jail; turn ends
+
+- **TC23: Player in jail, second turn in jail (`jailTurnCount = 2`)** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getJailTurnCount() = 2`, player did not pay or roll doubles this turn
+  - **Expected output**: completes without exception; `jailTurnCount` incremented to `3`; player remains in jail; turn ends
+
+- **TC24: Player in jail, third turn in jail (`jailTurnCount = 3`)** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getJailTurnCount() = 3`, player did not pay or roll doubles this turn
+  - **Expected output**: completes without exception; `jailTurnCount` remains `3`; player remains in jail; player must pay fee before rolling on the next turn (or implementation forces payment—document chosen behavior in controller Javadoc)
+
+- **TC25: Inactive player in jail** ( )
+  - **State of the system**: `player.inJail() = true`, `player.getActive() = false`
+  - **Expected output**: `false`; no state change

--- a/docs/bva/player.md
+++ b/docs/bva/player.md
@@ -221,18 +221,18 @@ For each test case, you may choose **any easy-to-read format** you like. Regardl
 
 Increments `jailTurnCount` by 1. No guard on `inJail` or `Constants.MAX_JAIL_TURNS`; callers (e.g. `JailController`) enforce those limits before invoking.
 
-- **TC37: Increment from initial count (0)** ( )
+- **TC37: Increment from initial count (0)** ( :white_check_mark: )
   - **State of the system**: `jailTurnCount = 0` (newly created player, not in jail)
   - **Expected output**: `jailTurnCount` becomes `1`; no other state change
 
-- **TC38: Increment from first jail turn (1)** ( )
+- **TC38: Increment from first jail turn (1)** ( :white_check_mark: )
   - **State of the system**: `jailTurnCount = 1` (e.g. after `goToJail()`)
   - **Expected output**: `jailTurnCount` becomes `2`; `inJail` and `position` unchanged
 
-- **TC39: Increment from one below max (2)** ( )
+- **TC39: Increment from one below max (2)** ( :white_check_mark: )
   - **State of the system**: `jailTurnCount = 2` (`Constants.MAX_JAIL_TURNS - 1`)
   - **Expected output**: `jailTurnCount` becomes `3` (`Constants.MAX_JAIL_TURNS`); player remains in jail
 
-- **TC40: Increment at max jail turns (3)** ( )
+- **TC40: Increment at max jail turns (3)** ( :white_check_mark: )
   - **State of the system**: `jailTurnCount = Constants.MAX_JAIL_TURNS` (= 3)
   - **Expected output**: `jailTurnCount` becomes `4` (method has no cap; documents raw `Player` behavior—callers must not invoke when count is already at max)

--- a/docs/bva/player.md
+++ b/docs/bva/player.md
@@ -215,3 +215,24 @@ For each test case, you may choose **any easy-to-read format** you like. Regardl
 - **TC36: Get jailTurnCount after leaving jail** ( :white_check_mark: )  
   - **State of the system**: player called goToJail() then leaveJail()  
   - **Expected output**: returns 0
+
+
+## Method under test: `incrementJailTurnCount()`
+
+Increments `jailTurnCount` by 1. No guard on `inJail` or `Constants.MAX_JAIL_TURNS`; callers (e.g. `JailController`) enforce those limits before invoking.
+
+- **TC37: Increment from initial count (0)** ( )
+  - **State of the system**: `jailTurnCount = 0` (newly created player, not in jail)
+  - **Expected output**: `jailTurnCount` becomes `1`; no other state change
+
+- **TC38: Increment from first jail turn (1)** ( )
+  - **State of the system**: `jailTurnCount = 1` (e.g. after `goToJail()`)
+  - **Expected output**: `jailTurnCount` becomes `2`; `inJail` and `position` unchanged
+
+- **TC39: Increment from one below max (2)** ( )
+  - **State of the system**: `jailTurnCount = 2` (`Constants.MAX_JAIL_TURNS - 1`)
+  - **Expected output**: `jailTurnCount` becomes `3` (`Constants.MAX_JAIL_TURNS`); player remains in jail
+
+- **TC40: Increment at max jail turns (3)** ( )
+  - **State of the system**: `jailTurnCount = Constants.MAX_JAIL_TURNS` (= 3)
+  - **Expected output**: `jailTurnCount` becomes `4` (method has no cap; documents raw `Player` behavior—callers must not invoke when count is already at max)

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -47,6 +47,9 @@ public class JailController {
 
     public boolean attemptRollDoubles(Player player){
         Objects.requireNonNull(player, "Player cannot be null");
+        if (!player.getActive()) {
+            return false;
+        }
         if (!player.inJail()) {
             return false;
         }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -54,6 +54,10 @@ public class JailController {
         if (dice.isDoubles()) {
             return releaseFromJail(player);
         }
+        player.incrementJailTurnCount();
+        if (player.getJailTurnCount() >= Constants.MAX_JAIL_TURNS) {
+            return payJailFee(player);
+        }
         return false;
     }
 

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -17,6 +17,9 @@ public class JailController {
 
     public boolean sendToJail(Player player){
         Objects.requireNonNull(player, "Player cannot be null");
-        return false;
+        if (!player.getActive()) {
+            return false;
+        }
+        return true;
     }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -32,6 +32,9 @@ public class JailController {
 
     public boolean payJailFee(Player player){
         Objects.requireNonNull(player, "Player cannot be null");
-        return false;
+        if (!player.inJail()) {
+            return false;
+        }
+       return true;
     }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -29,4 +29,9 @@ public class JailController {
         Objects.requireNonNull(player, "Player cannot be null");
         return player.leaveJail();
     }
+
+    public boolean payJailFee(Player player){
+        Objects.requireNonNull(player, "Player cannot be null");
+        return false;
+    }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -44,4 +44,9 @@ public class JailController {
         player.remove(Constants.JAIL_FEE);
         return player.leaveJail();
     }
+
+    public boolean attemptRollDoubles(Player player){
+        Objects.requireNonNull(player, "Player cannot be null");
+        return false;
+    }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -24,4 +24,8 @@ public class JailController {
         gameEngine.setPlayerPosition(player, Constants.JAIL_POSITION);
         return player.goToJail(Constants.JAIL_POSITION);
     }
+
+    public void releaseFromJail(Player player){
+        Objects.requireNonNull(player, "Player cannot be null");
+    }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -68,7 +68,10 @@ public class JailController {
         if (!player.inJail()) {
             return false;
         }
-        return false;
+        if (player.getJailTurnCount() < Constants.MAX_JAIL_TURNS) {
+            player.incrementJailTurnCount();
+        }
+        return true;
     }
 
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -54,9 +54,8 @@ public class JailController {
         if (dice.isDoubles()) {
             return releaseFromJail(player);
         }
-        player.incrementJailTurnCount();
-        if (player.getJailTurnCount() >= Constants.MAX_JAIL_TURNS) {
-            return payJailFee(player);
+        if (player.getJailTurnCount() < Constants.MAX_JAIL_TURNS) {
+            player.incrementJailTurnCount();
         }
         return false;
     }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -25,7 +25,8 @@ public class JailController {
         return player.goToJail(Constants.JAIL_POSITION);
     }
 
-    public void releaseFromJail(Player player){
+    public boolean releaseFromJail(Player player){
         Objects.requireNonNull(player, "Player cannot be null");
+        return player.leaveJail();
     }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -35,6 +35,10 @@ public class JailController {
         if (!player.inJail()) {
             return false;
         }
-       return true;
+        if (!player.canAfford(Constants.JAIL_FEE)) {
+            return false;
+        }
+        player.remove(Constants.JAIL_FEE);
+        return player.leaveJail();
     }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -32,6 +32,9 @@ public class JailController {
 
     public boolean payJailFee(Player player){
         Objects.requireNonNull(player, "Player cannot be null");
+        if (!player.getActive()) {
+            return false;
+        }
         if (!player.inJail()) {
             return false;
         }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -41,7 +41,9 @@ public class JailController {
         if (!player.canAfford(Constants.JAIL_FEE)) {
             return false;
         }
-        player.remove(Constants.JAIL_FEE);
+        if (!player.remove(Constants.JAIL_FEE)) {
+            return false;
+        }
         return player.leaveJail();
     }
 

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -63,4 +63,9 @@ public class JailController {
         return false;
     }
 
+    public boolean handleJailTurn(Player player){
+        Objects.requireNonNull(player, "Player cannot be null");
+        return false;
+    }
+
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -1,0 +1,18 @@
+package controller;
+
+import model.GameEngine;
+import model.Dice;
+import model.Player;
+public class JailController {
+    private final GameEngine gameEngine;
+    private final Dice dice;
+    public JailController(GameEngine gameEngine, Dice dice){
+        this.gameEngine = gameEngine;
+        this.dice = dice;
+
+    }
+
+    public boolean sendToJail(Player player){
+        return false;
+    }
+}

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -50,9 +50,11 @@ public class JailController {
         if (!player.inJail()) {
             return false;
         }
-        
+        dice.roll();
+        if (dice.isDoubles()) {
+            return releaseFromJail(player);
+        }
         return false;
-
     }
 
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 
 import model.Dice;
 import model.Player;
+import util.Constants;
 public class JailController {
     private final GameEngine gameEngine;
     private final Dice dice;
@@ -20,6 +21,7 @@ public class JailController {
         if (!player.getActive()) {
             return false;
         }
-        return true;
+        gameEngine.setPlayerPosition(player, Constants.JAIL_POSITION);
+        return player.goToJail(Constants.JAIL_POSITION);
     }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -1,16 +1,21 @@
 package controller;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import model.Dice;
 import model.GameEngine;
+import model.Player;
+import util.Constants;
 
 import java.util.Objects;
 
-import model.Dice;
-import model.Player;
-import util.Constants;
 public class JailController {
     private final GameEngine gameEngine;
     private final Dice dice;
-    public JailController(GameEngine gameEngine, Dice dice){
+
+    @SuppressFBWarnings(
+            value = "EI_EXPOSE_REP2",
+            justification = "Controller intentionally stores shared GameEngine and Dice references for game coordination.")
+    public JailController(GameEngine gameEngine, Dice dice) {
         this.gameEngine = gameEngine;
         this.dice = dice;
 

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -1,6 +1,9 @@
 package controller;
 
 import model.GameEngine;
+
+import java.util.Objects;
+
 import model.Dice;
 import model.Player;
 public class JailController {
@@ -13,6 +16,7 @@ public class JailController {
     }
 
     public boolean sendToJail(Player player){
+        Objects.requireNonNull(player, "Player cannot be null");
         return false;
     }
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -65,6 +65,9 @@ public class JailController {
 
     public boolean handleJailTurn(Player player){
         Objects.requireNonNull(player, "Player cannot be null");
+        if (!player.getActive()) {
+            return false;
+        }
         if (!player.inJail()) {
             return false;
         }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -47,6 +47,12 @@ public class JailController {
 
     public boolean attemptRollDoubles(Player player){
         Objects.requireNonNull(player, "Player cannot be null");
+        if (!player.inJail()) {
+            return false;
+        }
+        
         return false;
+
     }
+
 }

--- a/src/main/java/controller/JailController.java
+++ b/src/main/java/controller/JailController.java
@@ -65,6 +65,9 @@ public class JailController {
 
     public boolean handleJailTurn(Player player){
         Objects.requireNonNull(player, "Player cannot be null");
+        if (!player.inJail()) {
+            return false;
+        }
         return false;
     }
 

--- a/src/main/java/model/Player.java
+++ b/src/main/java/model/Player.java
@@ -122,6 +122,12 @@ public class Player {
     public boolean getActive() {
         return this.active;
     }
+
+    public void incrementJailTurnCount() {
+        this.jailTurnCount++;
+    }
+
+
     
 
 

--- a/src/main/java/util/Constants.java
+++ b/src/main/java/util/Constants.java
@@ -16,6 +16,8 @@ public class Constants {
     public static final double STOCK_MARKET_CRASH_LOSS = 200.0;
     public static final int MIN_DICE_ROLL = 2;
     public static final int MAX_DICE_ROLL = 12;
+    public static final double JAIL_FEE = 50.0;
+    public static final int MAX_JAIL_TURNS = 3;
 
     private Constants() {}
 

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -258,4 +258,20 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC14: attemptRollDoubles - Null player
+    @Test
+    public void TC14_AttemptRollDoubles_NullPlayer_ThrowsNullPointerException() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        EasyMock.replay(gameEngine, dice);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertThrows(NullPointerException.class,
+                () -> controller.attemptRollDoubles(null),
+                "attemptRollDoubles must reject a null player");
+
+        EasyMock.verify(gameEngine, dice);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -175,4 +175,23 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC10: payJailFee - Player in jail, cannot afford fee
+    @Test
+    public void TC10_PayJailFee_PlayerInJailCannotAfford_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        EasyMock.expect(player.canAfford(Constants.JAIL_FEE)).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.payJailFee(player),
+                "payJailFee must return false when the player cannot afford the fee");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -405,6 +405,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(false);
         EasyMock.replay(gameEngine, dice, player);
 
@@ -423,6 +424,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         EasyMock.expect(player.getJailTurnCount()).andReturn(1);
         player.incrementJailTurnCount();
@@ -444,6 +446,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         EasyMock.expect(player.getJailTurnCount()).andReturn(2);
         player.incrementJailTurnCount();
@@ -465,6 +468,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         EasyMock.expect(player.getJailTurnCount()).andReturn(Constants.MAX_JAIL_TURNS);
         EasyMock.replay(gameEngine, dice, player);
@@ -473,6 +477,24 @@ public class JailControllerTests {
 
         assertTrue(controller.handleJailTurn(player),
                 "handleJailTurn must return true when the player is at max jail turns");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
+    // TC25: handleJailTurn - Inactive player in jail
+    @Test
+    public void TC25_HandleJailTurn_InactivePlayerInJail_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.getActive()).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.handleJailTurn(player),
+                "handleJailTurn must return false for an inactive player in jail");
 
         EasyMock.verify(gameEngine, dice, player);
     }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -499,4 +499,26 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // Basis path gap: sendToJail propagates goToJail failure
+    @Test
+    public void TC_GAP1_SendToJail_GoToJailFails_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.getActive()).andReturn(true);
+        gameEngine.setPlayerPosition(player, Constants.JAIL_POSITION);
+        EasyMock.expectLastCall();
+        EasyMock.expect(player.goToJail(Constants.JAIL_POSITION)).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.sendToJail(player),
+                "sendToJail must return false when goToJail fails");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
+   
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -194,4 +194,25 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC11: payJailFee - Player in jail, balance exactly equals fee
+    @Test
+    public void TC11_PayJailFee_PlayerInJailExactBalance_ReturnsTrue() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        EasyMock.expect(player.canAfford(Constants.JAIL_FEE)).andReturn(true);
+        EasyMock.expect(player.remove(Constants.JAIL_FEE)).andReturn(true);
+        EasyMock.expect(player.leaveJail()).andReturn(true);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.payJailFee(player),
+                "payJailFee must return true when the player pays the exact jail fee");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -437,4 +437,25 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC23: handleJailTurn - Player in jail, second turn in jail
+    @Test
+    public void TC23_HandleJailTurn_PlayerInJailSecondTurn_IncrementsTurnCount() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        EasyMock.expect(player.getJailTurnCount()).andReturn(2);
+        player.incrementJailTurnCount();
+        EasyMock.expectLastCall();
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.handleJailTurn(player),
+                "handleJailTurn must return true when the second jail turn is recorded");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -215,4 +215,25 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC12: payJailFee - Player in jail, balance greater than fee
+    @Test
+    public void TC12_PayJailFee_PlayerInJailSurplusBalance_ReturnsTrue() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        EasyMock.expect(player.canAfford(Constants.JAIL_FEE)).andReturn(true);
+        EasyMock.expect(player.remove(Constants.JAIL_FEE)).andReturn(true);
+        EasyMock.expect(player.leaveJail()).andReturn(true);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.payJailFee(player),
+                "payJailFee must return true when the player has more than the jail fee");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -157,4 +157,22 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice);
     }
 
+    // TC9: payJailFee - Player not in jail
+    @Test
+    public void TC9_PayJailFee_PlayerNotInJail_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.payJailFee(player),
+                "payJailFee must return false when the player is not in jail");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -416,4 +416,25 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC22: handleJailTurn - Player in jail, first turn in jail
+    @Test
+    public void TC22_HandleJailTurn_PlayerInJailFirstTurn_IncrementsTurnCount() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        EasyMock.expect(player.getJailTurnCount()).andReturn(1);
+        player.incrementJailTurnCount();
+        EasyMock.expectLastCall();
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.handleJailTurn(player),
+                "handleJailTurn must return true when the first jail turn is recorded");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -141,4 +141,20 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC8: payJailFee - Null player
+    @Test
+    public void TC8_PayJailFee_NullPlayer_ThrowsNullPointerException() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        EasyMock.replay(gameEngine, dice);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertThrows(NullPointerException.class,
+                () -> controller.payJailFee(null),
+                "payJailFee must reject a null player");
+
+        EasyMock.verify(gameEngine, dice);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -398,4 +398,22 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice);
     }
 
+    // TC21: handleJailTurn - Player not in jail
+    @Test
+    public void TC21_HandleJailTurn_PlayerNotInJail_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.handleJailTurn(player),
+                "handleJailTurn must return false when the player is not in jail");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -89,4 +89,20 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC5: releaseFromJail - Null player
+    @Test
+    public void TC5_ReleaseFromJail_NullPlayer_ThrowsNullPointerException() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        EasyMock.replay(gameEngine, dice);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertThrows(NullPointerException.class,
+                () -> controller.releaseFromJail(null),
+                "releaseFromJail must reject a null player");
+
+        EasyMock.verify(gameEngine, dice);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -382,4 +382,20 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC20: handleJailTurn - Null player
+    @Test
+    public void TC20_HandleJailTurn_NullPlayer_ThrowsNullPointerException() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        EasyMock.replay(gameEngine, dice);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertThrows(NullPointerException.class,
+                () -> controller.handleJailTurn(null),
+                "handleJailTurn must reject a null player");
+
+        EasyMock.verify(gameEngine, dice);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -164,6 +164,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(false);
         EasyMock.replay(gameEngine, dice, player);
 
@@ -182,6 +183,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         EasyMock.expect(player.canAfford(Constants.JAIL_FEE)).andReturn(false);
         EasyMock.replay(gameEngine, dice, player);
@@ -201,6 +203,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         EasyMock.expect(player.canAfford(Constants.JAIL_FEE)).andReturn(true);
         EasyMock.expect(player.remove(Constants.JAIL_FEE)).andReturn(true);
@@ -222,6 +225,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         EasyMock.expect(player.canAfford(Constants.JAIL_FEE)).andReturn(true);
         EasyMock.expect(player.remove(Constants.JAIL_FEE)).andReturn(true);
@@ -232,6 +236,24 @@ public class JailControllerTests {
 
         assertTrue(controller.payJailFee(player),
                 "payJailFee must return true when the player has more than the jail fee");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
+    // TC13: payJailFee - Inactive player in jail
+    @Test
+    public void TC13_PayJailFee_InactivePlayerInJail_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.getActive()).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.payJailFee(player),
+                "payJailFee must return false for an inactive player in jail");
 
         EasyMock.verify(gameEngine, dice, player);
     }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -274,4 +274,22 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice);
     }
 
+    // TC15: attemptRollDoubles - Player not in jail
+    @Test
+    public void TC15_AttemptRollDoubles_PlayerNotInJail_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.attemptRollDoubles(player),
+                "attemptRollDoubles must return false when the player is not in jail");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -338,4 +338,26 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC18: attemptRollDoubles - Player in jail, dice not doubles, turn count at max
+    @Test
+    public void TC18_AttemptRollDoubles_PlayerInJailNoDoublesAtMaxTurns_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        dice.roll();
+        EasyMock.expectLastCall();
+        EasyMock.expect(dice.isDoubles()).andReturn(false);
+        EasyMock.expect(player.getJailTurnCount()).andReturn(Constants.MAX_JAIL_TURNS);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.attemptRollDoubles(player),
+                "attemptRollDoubles must return false when the player is at max jail turns");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -458,4 +458,23 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC24: handleJailTurn - Player in jail, third turn in jail
+    @Test
+    public void TC24_HandleJailTurn_PlayerInJailThirdTurn_DoesNotIncrementTurnCount() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        EasyMock.expect(player.getJailTurnCount()).andReturn(Constants.MAX_JAIL_TURNS);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.handleJailTurn(player),
+                "handleJailTurn must return true when the player is at max jail turns");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -562,7 +562,28 @@ public class JailControllerTests {
          EasyMock.verify(gameEngine, dice, player);
      }
  
-     
+     // Basis path gap: attemptRollDoubles propagates leaveJail failure on doubles
+     @Test
+     public void TC_GAP4_AttemptRollDoubles_DoublesButLeaveJailFails_ReturnsFalse() {
+         GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+         Dice dice = EasyMock.createMock(Dice.class);
+         Player player = EasyMock.createMock(Player.class);
+ 
+         EasyMock.expect(player.getActive()).andReturn(true);
+         EasyMock.expect(player.inJail()).andReturn(true);
+         dice.roll();
+         EasyMock.expectLastCall();
+         EasyMock.expect(dice.isDoubles()).andReturn(true);
+         EasyMock.expect(player.leaveJail()).andReturn(false);
+         EasyMock.replay(gameEngine, dice, player);
+ 
+         JailController controller = new JailController(gameEngine, dice);
+ 
+         assertFalse(controller.attemptRollDoubles(player),
+                 "attemptRollDoubles must return false when leaveJail fails after rolling doubles");
+ 
+         EasyMock.verify(gameEngine, dice, player);
+     }
  
      
  

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -1,0 +1,28 @@
+package controller;
+
+import model.Dice;
+import model.GameEngine;
+import org.easymock.EasyMock;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class JailControllerTests {
+
+    // TC1: sendToJail - Null player
+    @Test
+    public void TC1_SendToJail_NullPlayer_ThrowsNullPointerException() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        EasyMock.replay(gameEngine, dice);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertThrows(NullPointerException.class,
+                () -> controller.sendToJail(null),
+                "sendToJail must reject a null player");
+
+        EasyMock.verify(gameEngine, dice);
+    }
+
+}

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -519,6 +519,29 @@ public class JailControllerTests {
 
         EasyMock.verify(gameEngine, dice, player);
     }
+     // Basis path gap: payJailFee propagates remove failure
+     @Test
+     public void TC_GAP2_PayJailFee_RemoveFails_ReturnsFalse() {
+         GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+         Dice dice = EasyMock.createMock(Dice.class);
+         Player player = EasyMock.createMock(Player.class);
+ 
+         EasyMock.expect(player.getActive()).andReturn(true);
+         EasyMock.expect(player.inJail()).andReturn(true);
+         EasyMock.expect(player.canAfford(Constants.JAIL_FEE)).andReturn(true);
+         EasyMock.expect(player.remove(Constants.JAIL_FEE)).andReturn(false);
+         EasyMock.replay(gameEngine, dice, player);
+ 
+         JailController controller = new JailController(gameEngine, dice);
+ 
+         assertFalse(controller.payJailFee(player),
+                 "payJailFee must return false when remove fails");
+ 
+         EasyMock.verify(gameEngine, dice, player);
+     }
+ 
+     
+ 
 
    
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -123,4 +123,22 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC7: releaseFromJail - Player not in jail
+    @Test
+    public void TC7_ReleaseFromJail_PlayerNotInJail_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.leaveJail()).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.releaseFromJail(player),
+                "releaseFromJail must return false when the player is not in jail");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -539,6 +539,30 @@ public class JailControllerTests {
  
          EasyMock.verify(gameEngine, dice, player);
      }
+
+     // Basis path gap: payJailFee propagates leaveJail failure
+     @Test
+     public void TC_GAP3_PayJailFee_LeaveJailFails_ReturnsFalse() {
+         GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+         Dice dice = EasyMock.createMock(Dice.class);
+         Player player = EasyMock.createMock(Player.class);
+ 
+         EasyMock.expect(player.getActive()).andReturn(true);
+         EasyMock.expect(player.inJail()).andReturn(true);
+         EasyMock.expect(player.canAfford(Constants.JAIL_FEE)).andReturn(true);
+         EasyMock.expect(player.remove(Constants.JAIL_FEE)).andReturn(true);
+         EasyMock.expect(player.leaveJail()).andReturn(false);
+         EasyMock.replay(gameEngine, dice, player);
+ 
+         JailController controller = new JailController(gameEngine, dice);
+ 
+         assertFalse(controller.payJailFee(player),
+                 "payJailFee must return false when leaveJail fails");
+ 
+         EasyMock.verify(gameEngine, dice, player);
+     }
+ 
+     
  
      
  

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -281,6 +281,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(false);
         EasyMock.replay(gameEngine, dice, player);
 
@@ -299,6 +300,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         dice.roll();
         EasyMock.expectLastCall();
@@ -321,6 +323,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         dice.roll();
         EasyMock.expectLastCall();
@@ -345,6 +348,7 @@ public class JailControllerTests {
         Dice dice = EasyMock.createMock(Dice.class);
         Player player = EasyMock.createMock(Player.class);
 
+        EasyMock.expect(player.getActive()).andReturn(true);
         EasyMock.expect(player.inJail()).andReturn(true);
         dice.roll();
         EasyMock.expectLastCall();
@@ -356,6 +360,24 @@ public class JailControllerTests {
 
         assertFalse(controller.attemptRollDoubles(player),
                 "attemptRollDoubles must return false when the player is at max jail turns");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
+    // TC19: attemptRollDoubles - Inactive player in jail
+    @Test
+    public void TC19_AttemptRollDoubles_InactivePlayerInJail_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.getActive()).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.attemptRollDoubles(player),
+                "attemptRollDoubles must return false for an inactive player in jail");
 
         EasyMock.verify(gameEngine, dice, player);
     }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -68,4 +68,25 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC4: sendToJail - Active player already in jail
+    @Test
+    public void TC4_SendToJail_ActivePlayerAlreadyInJail_ReturnsTrue() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.getActive()).andReturn(true);
+        gameEngine.setPlayerPosition(player, Constants.JAIL_POSITION);
+        EasyMock.expectLastCall();
+        EasyMock.expect(player.goToJail(Constants.JAIL_POSITION)).andReturn(true);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.sendToJail(player),
+                "sendToJail must return true for an active player already in jail");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -314,4 +314,28 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC17: attemptRollDoubles - Player in jail, dice not doubles, turn count below max
+    @Test
+    public void TC17_AttemptRollDoubles_PlayerInJailNoDoubles_IncrementsTurnCount() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        dice.roll();
+        EasyMock.expectLastCall();
+        EasyMock.expect(dice.isDoubles()).andReturn(false);
+        EasyMock.expect(player.getJailTurnCount()).andReturn(1);
+        player.incrementJailTurnCount();
+        EasyMock.expectLastCall();
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.attemptRollDoubles(player),
+                "attemptRollDoubles must return false when the player does not roll doubles");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -105,4 +105,22 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice);
     }
 
+    // TC6: releaseFromJail - Player is in jail
+    @Test
+    public void TC6_ReleaseFromJail_PlayerInJail_ReturnsTrue() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.leaveJail()).andReturn(true);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.releaseFromJail(player),
+                "releaseFromJail must return true when the player leaves jail");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -2,9 +2,11 @@ package controller;
 
 import model.Dice;
 import model.GameEngine;
+import model.Player;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class JailControllerTests {
@@ -23,6 +25,24 @@ public class JailControllerTests {
                 "sendToJail must reject a null player");
 
         EasyMock.verify(gameEngine, dice);
+    }
+
+    // TC2: sendToJail - Inactive player
+    @Test
+    public void TC2_SendToJail_InactivePlayer_ReturnsFalse() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.getActive()).andReturn(false);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertFalse(controller.sendToJail(player),
+                "sendToJail must return false for an inactive player");
+
+        EasyMock.verify(gameEngine, dice, player);
     }
 
 }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -5,9 +5,11 @@ import model.GameEngine;
 import model.Player;
 import org.easymock.EasyMock;
 import org.junit.jupiter.api.Test;
+import util.Constants;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class JailControllerTests {
 
@@ -41,6 +43,27 @@ public class JailControllerTests {
 
         assertFalse(controller.sendToJail(player),
                 "sendToJail must return false for an inactive player");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
+    // TC3: sendToJail - Active player not in jail
+    @Test
+    public void TC3_SendToJail_ActivePlayerNotInJail_ReturnsTrue() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.getActive()).andReturn(true);
+        gameEngine.setPlayerPosition(player, Constants.JAIL_POSITION);
+        EasyMock.expectLastCall();
+        EasyMock.expect(player.goToJail(Constants.JAIL_POSITION)).andReturn(true);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.sendToJail(player),
+                "sendToJail must return true for an active player not in jail");
 
         EasyMock.verify(gameEngine, dice, player);
     }

--- a/src/test/java/controller/JailControllerTests.java
+++ b/src/test/java/controller/JailControllerTests.java
@@ -292,4 +292,26 @@ public class JailControllerTests {
         EasyMock.verify(gameEngine, dice, player);
     }
 
+    // TC16: attemptRollDoubles - Player in jail, dice roll is doubles
+    @Test
+    public void TC16_AttemptRollDoubles_PlayerInJailRollsDoubles_ReturnsTrue() {
+        GameEngine gameEngine = EasyMock.createMock(GameEngine.class);
+        Dice dice = EasyMock.createMock(Dice.class);
+        Player player = EasyMock.createMock(Player.class);
+
+        EasyMock.expect(player.inJail()).andReturn(true);
+        dice.roll();
+        EasyMock.expectLastCall();
+        EasyMock.expect(dice.isDoubles()).andReturn(true);
+        EasyMock.expect(player.leaveJail()).andReturn(true);
+        EasyMock.replay(gameEngine, dice, player);
+
+        JailController controller = new JailController(gameEngine, dice);
+
+        assertTrue(controller.attemptRollDoubles(player),
+                "attemptRollDoubles must return true when the player rolls doubles");
+
+        EasyMock.verify(gameEngine, dice, player);
+    }
+
 }

--- a/src/test/java/model/PlayerTests.java
+++ b/src/test/java/model/PlayerTests.java
@@ -556,6 +556,21 @@ public class PlayerTests {
         assertTrue(player.inJail(), "player should remain in jail");
     }
 
+
+    @Test
+    public void TC40_IncrementJailTurnCount_AtMax_IncrementsPastMax() {
+        Player player = new Player("John", 100.0);
+        player.goToJail(Constants.JAIL_POSITION);
+        player.incrementJailTurnCount();
+        player.incrementJailTurnCount();
+
+        player.incrementJailTurnCount();
+
+        assertEquals(Constants.MAX_JAIL_TURNS + 1, player.getJailTurnCount(),
+                "incrementJailTurnCount has no cap and should increment past MAX_JAIL_TURNS");
+    }
+
+
   
 
 

--- a/src/test/java/model/PlayerTests.java
+++ b/src/test/java/model/PlayerTests.java
@@ -512,4 +512,21 @@ public class PlayerTests {
         assertEquals(0, jailTurnCount, "jailTurnCount should be 0 after leaving jail");
     }
 
+    // ==================================================================================================
+    // Test suite for incrementJailTurnCount method (TC37–TC40)
+    // ==================================================================================================
+
+    @Test
+    public void TC37_IncrementJailTurnCount_FromZero_IncrementsToOne() {
+        Player player = new Player("John", 100.0);
+
+        player.incrementJailTurnCount();
+
+        assertEquals(1, player.getJailTurnCount(),
+                "jailTurnCount should be 1 after incrementing from 0");
+        assertFalse(player.inJail(), "incrementJailTurnCount should not change inJail");
+        assertEquals(0, player.getPosition(),
+                "incrementJailTurnCount should not change position");
+    }
+
 }

--- a/src/test/java/model/PlayerTests.java
+++ b/src/test/java/model/PlayerTests.java
@@ -529,4 +529,22 @@ public class PlayerTests {
                 "incrementJailTurnCount should not change position");
     }
 
+
+    @Test
+    public void TC38_IncrementJailTurnCount_FromOne_IncrementsToTwo() {
+        Player player = new Player("John", 100.0);
+        player.goToJail(Constants.JAIL_POSITION);
+
+        player.incrementJailTurnCount();
+
+        assertEquals(2, player.getJailTurnCount(),
+                "jailTurnCount should be 2 after incrementing from 1");
+        assertTrue(player.inJail(), "player should remain in jail");
+        assertEquals(Constants.JAIL_POSITION, player.getPosition(),
+                "position should remain unchanged");
+    }
+
+  
+
+
 }

--- a/src/test/java/model/PlayerTests.java
+++ b/src/test/java/model/PlayerTests.java
@@ -543,6 +543,18 @@ public class PlayerTests {
         assertEquals(Constants.JAIL_POSITION, player.getPosition(),
                 "position should remain unchanged");
     }
+    @Test
+    public void TC39_IncrementJailTurnCount_FromTwo_IncrementsToMax() {
+        Player player = new Player("John", 100.0);
+        player.goToJail(Constants.JAIL_POSITION);
+        player.incrementJailTurnCount();
+
+        player.incrementJailTurnCount();
+
+        assertEquals(Constants.MAX_JAIL_TURNS, player.getJailTurnCount(),
+                "jailTurnCount should reach MAX_JAIL_TURNS after incrementing from 2");
+        assertTrue(player.inJail(), "player should remain in jail");
+    }
 
   
 


### PR DESCRIPTION
Controller for the JailController class. This PR contains that class as well as some minor edits to player to increment jail turn, GameEngine to take it from package private to public, and tests for all the jail controller functions. It already has 100 percent basis path coverage and kills all mutants. Also added two new constants required for Jail behavior in the constants file. 

Functions include: 
- send to jail - sends the player to jail 
- release from jail - releases the player from jail 
- pay jail fee - player can choose to pay the jail fee
- attempt to roll doubles - player can try their luck and roll doubles to get free
- handle jail turn


