### PR TITLE
Wip i18n

### DIFF
--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -53,7 +53,7 @@
     - **State of the system**: key is not in the resource bundle
     - **Expected output**: throws `MissingResourceException`
 
-- **TC11: getMessage_WithNullKey_ThrowsException**
+- **TC11: getMessage_WithNullKey_ThrowsException** ( :white_check_mark: )
     - **State of the system**: key = `null`
     - **Expected output**: throws `NullPointerException`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -32,7 +32,7 @@
     - **State of the system**: manager is initialized
     - **Expected output**: returns supported locales containing English and Spanish
 
-- **TC7: getSupportedLocales_WhenCallerModifiesReturnedList_ThrowsException**
+- **TC7: getSupportedLocales_WhenCallerModifiesReturnedList_ThrowsException** ( :white_check_mark: )
     - **State of the system**: caller attempts to add another locale to the returned list
     - **Expected output**: throws `UnsupportedOperationException`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -66,7 +66,7 @@
     - **State of the system**: active locale = English, key = `mainMenu.playerLabel`, argument = `1`
     - **Expected output**: returns `Player 1`
 
-- **TC13: formatMessage_WithSpanishLocaleAndPlayerNumber_ReturnsFormattedSpanishLabel**
+- **TC13: formatMessage_WithSpanishLocaleAndPlayerNumber_ReturnsFormattedSpanishLabel** ( :white_check_mark: )
     - **State of the system**: active locale = Spanish, key = `mainMenu.playerLabel`, argument = `1`
     - **Expected output**: returns `Jugador 1`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -45,7 +45,7 @@
     - **State of the system**: active locale = English, key = `mainMenu.title`
     - **Expected output**: returns `Monopoly`
 
-- **TC9: getMessage_WithSpanishLocaleAndTitleKey_ReturnsSpanishTitle**
+- **TC9: getMessage_WithSpanishLocaleAndTitleKey_ReturnsSpanishTitle** ( :white_check_mark: )
     - **State of the system**: active locale = Spanish, key = `mainMenu.title`
     - **Expected output**: returns `Monopolio`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -11,7 +11,7 @@
     - **State of the system**: locale = `Locale.ENGLISH`
     - **Expected output**: `getLocale()` returns `Locale.ENGLISH`
 
-- **TC3: setLocale_WithSpanishLocale_SetsLocaleToSpanish**
+- **TC3: setLocale_WithSpanishLocale_SetsLocaleToSpanish** ( :white_check_mark: )
     - **State of the system**: locale = Spanish locale
     - **Expected output**: `getLocale()` returns Spanish locale
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -3,7 +3,7 @@
 2. Input: locale category, Output: selected supported locale
 3. Input values: English locale, Spanish locale, unsupported locale, null locale
 
-- **TC1: getLocale_WithDefaultSystemLocale_ReturnsSupportedLocale**
+- **TC1: getLocale_WithDefaultSystemLocale_ReturnsSupportedLocale** ( :white_check_mark: )
     - **State of the system**: `LocalizationManager` has just loaded
     - **Expected output**: returns one of the supported locales
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -15,7 +15,7 @@
     - **State of the system**: locale = Spanish locale
     - **Expected output**: `getLocale()` returns Spanish locale
 
-- **TC4: setLocale_WithUnsupportedLocale_FallsBackToEnglish**
+- **TC4: setLocale_WithUnsupportedLocale_FallsBackToEnglish** ( :white_check_mark: )
     - **State of the system**: locale = unsupported locale
     - **Expected output**: `getLocale()` returns `Locale.ENGLISH`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -19,7 +19,7 @@
     - **State of the system**: locale = unsupported locale
     - **Expected output**: `getLocale()` returns `Locale.ENGLISH`
 
-- **TC5: setLocale_WithNullLocale_ThrowsException**
+- **TC5: setLocale_WithNullLocale_ThrowsException** ( :white_check_mark: )
     - **State of the system**: locale = `null`
     - **Expected output**: throws `NullPointerException`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -28,7 +28,7 @@
 2. Input: none, Output: collection size and contents
 3. Output values: English and Spanish
 
-- **TC6: getSupportedLocales_ReturnsEnglishAndSpanish**
+- **TC6: getSupportedLocales_ReturnsEnglishAndSpanish** ( :white_check_mark: )
     - **State of the system**: manager is initialized
     - **Expected output**: returns supported locales containing English and Spanish
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -49,7 +49,7 @@
     - **State of the system**: active locale = Spanish, key = `mainMenu.title`
     - **Expected output**: returns `Monopolio`
 
-- **TC10: getMessage_WithMissingKey_ThrowsException**
+- **TC10: getMessage_WithMissingKey_ThrowsException** ( :white_check_mark: )
     - **State of the system**: key is not in the resource bundle
     - **Expected output**: throws `MissingResourceException`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -7,7 +7,7 @@
     - **State of the system**: `LocalizationManager` has just loaded
     - **Expected output**: returns one of the supported locales
 
-- **TC2: setLocale_WithEnglishLocale_SetsLocaleToEnglish**
+- **TC2: setLocale_WithEnglishLocale_SetsLocaleToEnglish** ( :white_check_mark: )
     - **State of the system**: locale = `Locale.ENGLISH`
     - **Expected output**: `getLocale()` returns `Locale.ENGLISH`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -62,7 +62,7 @@
 2. Input: key and argument category, Output: substituted string
 3. Input values: one replacement value, no replacement values
 
-- **TC12: formatMessage_WithEnglishLocaleAndPlayerNumber_ReturnsFormattedEnglishLabel**
+- **TC12: formatMessage_WithEnglishLocaleAndPlayerNumber_ReturnsFormattedEnglishLabel** ( :white_check_mark: )
     - **State of the system**: active locale = English, key = `mainMenu.playerLabel`, argument = `1`
     - **Expected output**: returns `Player 1`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -1,0 +1,75 @@
+### Method under test: `setLocale(Locale locale)` and `getLocale()`
+1. Input: requested locale, Output: active locale
+2. Input: locale category, Output: selected supported locale
+3. Input values: English locale, Spanish locale, unsupported locale, null locale
+
+- **TC1: getLocale_WithDefaultSystemLocale_ReturnsSupportedLocale**
+    - **State of the system**: `LocalizationManager` has just loaded
+    - **Expected output**: returns one of the supported locales
+
+- **TC2: setLocale_WithEnglishLocale_SetsLocaleToEnglish**
+    - **State of the system**: locale = `Locale.ENGLISH`
+    - **Expected output**: `getLocale()` returns `Locale.ENGLISH`
+
+- **TC3: setLocale_WithSpanishLocale_SetsLocaleToSpanish**
+    - **State of the system**: locale = Spanish locale
+    - **Expected output**: `getLocale()` returns Spanish locale
+
+- **TC4: setLocale_WithUnsupportedLocale_FallsBackToEnglish**
+    - **State of the system**: locale = unsupported locale
+    - **Expected output**: `getLocale()` returns `Locale.ENGLISH`
+
+- **TC5: setLocale_WithNullLocale_ThrowsException**
+    - **State of the system**: locale = `null`
+    - **Expected output**: throws `NullPointerException`
+
+### Method under test: `getSupportedLocales()`
+1. Input: none, Output: supported locales
+2. Input: none, Output: collection size and contents
+3. Output values: English and Spanish
+
+- **TC6: getSupportedLocales_ReturnsEnglishAndSpanish**
+    - **State of the system**: manager is initialized
+    - **Expected output**: returns supported locales containing English and Spanish
+
+- **TC7: getSupportedLocales_WhenCallerModifiesReturnedList_ThrowsException**
+    - **State of the system**: caller attempts to add another locale to the returned list
+    - **Expected output**: throws `UnsupportedOperationException`
+
+### Method under test: `getMessage(String key)`
+1. Input: message key, Output: localized message
+2. Input: key category, Output: localized string or exception
+3. Input values: valid title key, missing key, null key
+
+- **TC8: getMessage_WithEnglishLocaleAndTitleKey_ReturnsEnglishTitle**
+    - **State of the system**: active locale = English, key = `mainMenu.title`
+    - **Expected output**: returns `Monopoly`
+
+- **TC9: getMessage_WithSpanishLocaleAndTitleKey_ReturnsSpanishTitle**
+    - **State of the system**: active locale = Spanish, key = `mainMenu.title`
+    - **Expected output**: returns `Monopolio`
+
+- **TC10: getMessage_WithMissingKey_ThrowsException**
+    - **State of the system**: key is not in the resource bundle
+    - **Expected output**: throws `MissingResourceException`
+
+- **TC11: getMessage_WithNullKey_ThrowsException**
+    - **State of the system**: key = `null`
+    - **Expected output**: throws `NullPointerException`
+
+### Method under test: `formatMessage(String key, Object... arguments)`
+1. Input: message key and replacement arguments, Output: formatted localized message
+2. Input: key and argument category, Output: substituted string
+3. Input values: one replacement value, no replacement values
+
+- **TC12: formatMessage_WithEnglishLocaleAndPlayerNumber_ReturnsFormattedEnglishLabel**
+    - **State of the system**: active locale = English, key = `mainMenu.playerLabel`, argument = `1`
+    - **Expected output**: returns `Player 1`
+
+- **TC13: formatMessage_WithSpanishLocaleAndPlayerNumber_ReturnsFormattedSpanishLabel**
+    - **State of the system**: active locale = Spanish, key = `mainMenu.playerLabel`, argument = `1`
+    - **Expected output**: returns `Jugador 1`
+
+- **TC14: formatMessage_WithNoArgumentsForParameterizedMessage_ReturnsTemplateText**
+    - **State of the system**: active locale = English, key = `mainMenu.playerLabel`, no arguments
+    - **Expected output**: returns unresolved template text from `MessageFormat`

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -41,7 +41,7 @@
 2. Input: key category, Output: localized string or exception
 3. Input values: valid title key, missing key, null key
 
-- **TC8: getMessage_WithEnglishLocaleAndTitleKey_ReturnsEnglishTitle**
+- **TC8: getMessage_WithEnglishLocaleAndTitleKey_ReturnsEnglishTitle** ( :white_check_mark: )
     - **State of the system**: active locale = English, key = `mainMenu.title`
     - **Expected output**: returns `Monopoly`
 

--- a/docs/bva/LocalizationManager.md
+++ b/docs/bva/LocalizationManager.md
@@ -70,6 +70,6 @@
     - **State of the system**: active locale = Spanish, key = `mainMenu.playerLabel`, argument = `1`
     - **Expected output**: returns `Jugador 1`
 
-- **TC14: formatMessage_WithNoArgumentsForParameterizedMessage_ReturnsTemplateText**
+- **TC14: formatMessage_WithNoArgumentsForParameterizedMessage_ReturnsTemplateText** ( :white_check_mark: )
     - **State of the system**: active locale = English, key = `mainMenu.playerLabel`, no arguments
     - **Expected output**: returns unresolved template text from `MessageFormat`

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -14,4 +14,7 @@ public final class LocalizationManager {
         return ENGLISH;
     }
 
+    public static void setLocale(Locale locale) {
+    }
+
 }

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -1,0 +1,17 @@
+package util;
+
+import java.util.Locale;
+
+public final class LocalizationManager {
+
+    public static final Locale ENGLISH = Locale.ENGLISH;
+    public static final Locale SPANISH = new Locale("es");
+
+    private LocalizationManager() {
+    }
+
+    public static Locale getLocale() {
+        return ENGLISH;
+    }
+
+}

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -17,7 +17,12 @@ public final class LocalizationManager {
     }
 
     public static void setLocale(Locale locale) {
-        currentLocale = locale;
+        if (locale.getLanguage().equals(SPANISH.getLanguage())) {
+            currentLocale = SPANISH;
+            return;
+        }
+
+        currentLocale = ENGLISH;
     }
 
 }

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -26,6 +26,7 @@ public final class LocalizationManager {
     }
 
     public static String getMessage(String key) {
+        Objects.requireNonNull(key, "Message key cannot be null");
         return messages.getString(key);
     }
 

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -1,6 +1,7 @@
 package util;
 
 import java.util.Locale;
+import java.util.Objects;
 
 public final class LocalizationManager {
 
@@ -17,6 +18,8 @@ public final class LocalizationManager {
     }
 
     public static void setLocale(Locale locale) {
+        Objects.requireNonNull(locale, "Locale cannot be null");
+
         if (locale.getLanguage().equals(SPANISH.getLanguage())) {
             currentLocale = SPANISH;
             return;

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -1,5 +1,6 @@
 package util;
 
+import java.text.MessageFormat;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
@@ -28,6 +29,10 @@ public final class LocalizationManager {
     public static String getMessage(String key) {
         Objects.requireNonNull(key, "Message key cannot be null");
         return messages.getString(key);
+    }
+
+    public static String formatMessage(String key, Object... arguments) {
+        return MessageFormat.format(getMessage(key), arguments);
     }
 
     public static void setLocale(Locale locale) {

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -7,14 +7,17 @@ public final class LocalizationManager {
     public static final Locale ENGLISH = Locale.ENGLISH;
     public static final Locale SPANISH = new Locale("es");
 
+    private static Locale currentLocale = ENGLISH;
+
     private LocalizationManager() {
     }
 
     public static Locale getLocale() {
-        return ENGLISH;
+        return currentLocale;
     }
 
     public static void setLocale(Locale locale) {
+        currentLocale = locale;
     }
 
 }

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -34,6 +34,7 @@ public final class LocalizationManager {
 
         if (locale.getLanguage().equals(SPANISH.getLanguage())) {
             currentLocale = SPANISH;
+            messages = ResourceBundle.getBundle(BUNDLE_NAME, currentLocale);
             return;
         }
 

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -1,5 +1,6 @@
 package util;
 
+import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
@@ -15,6 +16,10 @@ public final class LocalizationManager {
 
     public static Locale getLocale() {
         return currentLocale;
+    }
+
+    public static List<Locale> getSupportedLocales() {
+        return List.of(ENGLISH, SPANISH);
     }
 
     public static void setLocale(Locale locale) {

--- a/src/main/java/util/LocalizationManager.java
+++ b/src/main/java/util/LocalizationManager.java
@@ -3,13 +3,16 @@ package util;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
+import java.util.ResourceBundle;
 
 public final class LocalizationManager {
+    private static final String BUNDLE_NAME = "i18n.messages";
 
     public static final Locale ENGLISH = Locale.ENGLISH;
     public static final Locale SPANISH = new Locale("es");
 
     private static Locale currentLocale = ENGLISH;
+    private static ResourceBundle messages = ResourceBundle.getBundle(BUNDLE_NAME, currentLocale);
 
     private LocalizationManager() {
     }
@@ -22,6 +25,10 @@ public final class LocalizationManager {
         return List.of(ENGLISH, SPANISH);
     }
 
+    public static String getMessage(String key) {
+        return messages.getString(key);
+    }
+
     public static void setLocale(Locale locale) {
         Objects.requireNonNull(locale, "Locale cannot be null");
 
@@ -31,6 +38,7 @@ public final class LocalizationManager {
         }
 
         currentLocale = ENGLISH;
+        messages = ResourceBundle.getBundle(BUNDLE_NAME, currentLocale);
     }
 
 }

--- a/src/main/resources/i18n/messages_en.properties
+++ b/src/main/resources/i18n/messages_en.properties
@@ -1,1 +1,13 @@
 app.title=Monopoly
+mainMenu.title=Monopoly
+mainMenu.playersLabel=Players
+mainMenu.languageLabel=Language
+mainMenu.startButton=Start Game
+mainMenu.playerLabel=Player {0}
+mainMenu.defaultPlayerName=Player {0}
+mainMenu.chooseIconTooltip=Choose player {0} icon
+mainMenu.chooseIconDialogTitle=Choose Player Icon
+mainMenu.imageFileFilter=Image files
+mainMenu.invalidIconMessage=Please choose a valid image file.
+mainMenu.language.english=English
+mainMenu.language.spanish=Spanish

--- a/src/main/resources/i18n/messages_es.properties
+++ b/src/main/resources/i18n/messages_es.properties
@@ -1,1 +1,13 @@
-app.title = Monopolio
+app.title=Monopolio
+mainMenu.title=Monopolio
+mainMenu.playersLabel=Jugadores
+mainMenu.languageLabel=Idioma
+mainMenu.startButton=Iniciar juego
+mainMenu.playerLabel=Jugador {0}
+mainMenu.defaultPlayerName=Jugador {0}
+mainMenu.chooseIconTooltip=Elegir icono del jugador {0}
+mainMenu.chooseIconDialogTitle=Elegir icono del jugador
+mainMenu.imageFileFilter=Archivos de imagen
+mainMenu.invalidIconMessage=Elige un archivo de imagen valido.
+mainMenu.language.english=Ingles
+mainMenu.language.spanish=Espanol

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LocalizationManagerTests {
@@ -44,6 +45,11 @@ public class LocalizationManagerTests {
         Locale actual = LocalizationManager.getLocale();
 
         assertEquals(Locale.ENGLISH, actual);
+    }
+
+    @Test
+    public void setLocale_WithNullLocale_ThrowsException() {
+        assertThrows(NullPointerException.class, () -> LocalizationManager.setLocale(null));
     }
 
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -1,0 +1,21 @@
+package util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Locale;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class LocalizationManagerTests {
+
+    @Test
+    public void getLocale_WithDefaultSystemLocale_ReturnsSupportedLocale() {
+        Locale actual = LocalizationManager.getLocale();
+
+        boolean isSupportedLocale = actual.equals(LocalizationManager.ENGLISH)
+                || actual.equals(LocalizationManager.SPANISH);
+
+        assertTrue(isSupportedLocale);
+    }
+
+}

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Locale;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class LocalizationManagerTests {
@@ -16,6 +17,15 @@ public class LocalizationManagerTests {
                 || actual.equals(LocalizationManager.SPANISH);
 
         assertTrue(isSupportedLocale);
+    }
+
+    @Test
+    public void setLocale_WithEnglishLocale_SetsLocaleToEnglish() {
+        LocalizationManager.setLocale(Locale.ENGLISH);
+
+        Locale actual = LocalizationManager.getLocale();
+
+        assertEquals(Locale.ENGLISH, actual);
     }
 
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -77,4 +77,13 @@ public class LocalizationManagerTests {
         assertEquals("Monopoly", actual);
     }
 
+    @Test
+    public void getMessage_WithSpanishLocaleAndTitleKey_ReturnsSpanishTitle() {
+        LocalizationManager.setLocale(LocalizationManager.SPANISH);
+
+        String actual = LocalizationManager.getMessage("mainMenu.title");
+
+        assertEquals("Monopolio", actual);
+    }
+
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -37,4 +37,13 @@ public class LocalizationManagerTests {
         assertEquals(LocalizationManager.SPANISH, actual);
     }
 
+    @Test
+    public void setLocale_WithUnsupportedLocale_FallsBackToEnglish() {
+        LocalizationManager.setLocale(Locale.FRENCH);
+
+        Locale actual = LocalizationManager.getLocale();
+
+        assertEquals(Locale.ENGLISH, actual);
+    }
+
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -115,4 +115,13 @@ public class LocalizationManagerTests {
         assertEquals("Jugador 1", actual);
     }
 
+    @Test
+    public void formatMessage_WithNoArgumentsForParameterizedMessage_ReturnsTemplateText() {
+        LocalizationManager.setLocale(Locale.ENGLISH);
+
+        String actual = LocalizationManager.formatMessage("mainMenu.playerLabel");
+
+        assertEquals("Player {0}", actual);
+    }
+
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -68,4 +68,13 @@ public class LocalizationManagerTests {
         assertThrows(UnsupportedOperationException.class, () -> supportedLocales.add(Locale.FRENCH));
     }
 
+    @Test
+    public void getMessage_WithEnglishLocaleAndTitleKey_ReturnsEnglishTitle() {
+        LocalizationManager.setLocale(Locale.ENGLISH);
+
+        String actual = LocalizationManager.getMessage("mainMenu.title");
+
+        assertEquals("Monopoly", actual);
+    }
+
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -28,4 +28,13 @@ public class LocalizationManagerTests {
         assertEquals(Locale.ENGLISH, actual);
     }
 
+    @Test
+    public void setLocale_WithSpanishLocale_SetsLocaleToSpanish() {
+        LocalizationManager.setLocale(LocalizationManager.SPANISH);
+
+        Locale actual = LocalizationManager.getLocale();
+
+        assertEquals(LocalizationManager.SPANISH, actual);
+    }
+
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.MissingResourceException;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -84,6 +85,11 @@ public class LocalizationManagerTests {
         String actual = LocalizationManager.getMessage("mainMenu.title");
 
         assertEquals("Monopolio", actual);
+    }
+
+    @Test
+    public void getMessage_WithMissingKey_ThrowsException() {
+        assertThrows(MissingResourceException.class, () -> LocalizationManager.getMessage("missing.key"));
     }
 
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -106,4 +106,13 @@ public class LocalizationManagerTests {
         assertEquals("Player 1", actual);
     }
 
+    @Test
+    public void formatMessage_WithSpanishLocaleAndPlayerNumber_ReturnsFormattedSpanishLabel() {
+        LocalizationManager.setLocale(LocalizationManager.SPANISH);
+
+        String actual = LocalizationManager.formatMessage("mainMenu.playerLabel", 1);
+
+        assertEquals("Jugador 1", actual);
+    }
+
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -2,6 +2,7 @@ package util;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Locale;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -50,6 +51,14 @@ public class LocalizationManagerTests {
     @Test
     public void setLocale_WithNullLocale_ThrowsException() {
         assertThrows(NullPointerException.class, () -> LocalizationManager.setLocale(null));
+    }
+
+    @Test
+    public void getSupportedLocales_ReturnsEnglishAndSpanish() {
+        List<Locale> supportedLocales = LocalizationManager.getSupportedLocales();
+
+        assertTrue(supportedLocales.contains(LocalizationManager.ENGLISH));
+        assertTrue(supportedLocales.contains(LocalizationManager.SPANISH));
     }
 
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -92,4 +92,9 @@ public class LocalizationManagerTests {
         assertThrows(MissingResourceException.class, () -> LocalizationManager.getMessage("missing.key"));
     }
 
+    @Test
+    public void getMessage_WithNullKey_ThrowsException() {
+        assertThrows(NullPointerException.class, () -> LocalizationManager.getMessage(null));
+    }
+
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -97,4 +97,13 @@ public class LocalizationManagerTests {
         assertThrows(NullPointerException.class, () -> LocalizationManager.getMessage(null));
     }
 
+    @Test
+    public void formatMessage_WithEnglishLocaleAndPlayerNumber_ReturnsFormattedEnglishLabel() {
+        LocalizationManager.setLocale(Locale.ENGLISH);
+
+        String actual = LocalizationManager.formatMessage("mainMenu.playerLabel", 1);
+
+        assertEquals("Player 1", actual);
+    }
+
 }

--- a/src/test/java/util/LocalizationManagerTests.java
+++ b/src/test/java/util/LocalizationManagerTests.java
@@ -61,4 +61,11 @@ public class LocalizationManagerTests {
         assertTrue(supportedLocales.contains(LocalizationManager.SPANISH));
     }
 
+    @Test
+    public void getSupportedLocales_WhenCallerModifiesReturnedList_ThrowsException() {
+        List<Locale> supportedLocales = LocalizationManager.getSupportedLocales();
+
+        assertThrows(UnsupportedOperationException.class, () -> supportedLocales.add(Locale.FRENCH));
+    }
+
 }


### PR DESCRIPTION
## Wip i18n

Add LocalizationManager with BVA-driven unit tests

## Description

This PR adds a shared `LocalizationManager` utility for application-wide i18n support and documents/tests its behavior through BVA.

## Changes

- Added `util.LocalizationManager`
- Added English and Spanish locale constants
- Added active locale state with fallback to English for unsupported locales
- Added supported locale list access
- Added localized message lookup through `ResourceBundle`
- Added formatted message lookup through `MessageFormat`
- Added BVA documentation for `LocalizationManager`
- Added unit tests for all `LocalizationManager` BVA cases

## Test Coverage

- Default locale is supported
- Setting English and Spanish locales
- Unsupported locale fallback
- Null locale handling
- Supported locale list contents and immutability
- English and Spanish message lookup
- Missing and null message key behavior
- English and Spanish formatted messages
- Parameterized message formatting with no arguments

## Notes

- This PR is intentionally focused on the reusable i18n utility and its unit tests.
- Main menu integration should be handled separately after this branch is merged.