### PR TITLE
Return to main menu after a game is won

### DIFF
--- a/src/main/java/view/BoardView.java
+++ b/src/main/java/view/BoardView.java
@@ -139,6 +139,13 @@ public class BoardView extends JFrame {
                 message,
                 LocalizationManager.getMessage("board.brand"),
                 JOptionPane.INFORMATION_MESSAGE);
+        returnToMainMenu();
+    }
+
+    /** Closes the finished game and reopens the main menu so a new game can be started. */
+    private void returnToMainMenu() {
+        dispose();
+        new MainMenuView().setVisible(true);
     }
 
 


### PR DESCRIPTION
This pull request adds functionality to improve the user experience when a game finishes. Now, after displaying the winner, the application automatically returns to the main menu, allowing the user to start a new game without manually closing the finished game window.

User flow improvement:

* Added a new private method `returnToMainMenu()` in `BoardView.java` that disposes of the current game window and opens the main menu after the game ends. This method is called after showing the winner message.